### PR TITLE
fix: keep `.ts` files as TypeScript when `jsx` options are set

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,8 +31,6 @@ function makeLoader() {
       const ext = filename.slice(filename.lastIndexOf("."));
       if (ext === ".js") {
         transformOptions.lang = "jsx";
-      } else if (ext === ".ts") {
-        transformOptions.lang = "tsx";
       }
     }
 

--- a/test/fixtures/typescript.ts
+++ b/test/fixtures/typescript.ts
@@ -3,6 +3,15 @@ interface Person {
   age: number;
 }
 
+type Node<T> = {
+  name: string;
+}
+
+// Generic arrow function — must stay parseable as TS, not TSX (where `<T>` would be a JSX tag)
+const traverse = <T>(node: Node<T> | null, visit: (node: Node<T>) => void) => {
+  return false
+};
+
 function greet(person: Person): string {
   return `Hello, ${person.name}! You are ${person.age} years old.`;
 }

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -95,6 +95,26 @@ describe("oxc-loader", () => {
     expect(files["bundle.js"]).not.toContain("<div>");
   });
 
+  it("transforms TypeScript and TSX together in one build", async () => {
+    const files = await compile(
+      [
+        path.join(__dirname, "fixtures", "typescript.ts"),
+        path.join(__dirname, "fixtures", "typescript-jsx.tsx"),
+      ],
+      {
+        jsx: {
+          runtime: "automatic",
+        },
+      },
+    );
+    expect(files["bundle.js"]).toContain("greet");
+    expect(files["bundle.js"]).toContain("react/jsx-runtime");
+    expect(files["bundle.js"]).not.toContain(": string");
+    expect(files["bundle.js"]).not.toContain(": number");
+    expect(files["bundle.js"]).not.toContain(": Props");
+    expect(files["bundle.js"]).not.toContain("<div>");
+  });
+
   it("generates source maps when enabled", async () => {
     const files = await compile(
       path.join(__dirname, "fixtures", "basic.js"),


### PR DESCRIPTION
## Problem

When a single `oxc-loader` rule handles both `.ts` and `.tsx` files (the typical setup — one rule `test: /\.[jt]sx?$/` with `jsx` options for TSX), valid TypeScript in `.ts` files starts failing with parse errors.

Example from `test/fixtures/typescript.ts`:

```ts
type Node<T> = { name: string }

const traverse = <T>(node: Node<T> | null, visit: (node: Node<T>) => void) => {
  return false
}
```

Webpack fails during build:

```
Module build failed (from ./src/index.js):
Error: Unexpected token. Did you mean `{'>'}` or `&gt;`?
```

### Root cause

`src/index.js` had a `lang` auto-detection: whenever `jsx` options were present, `.ts` files were force-set to `lang: "tsx"`.

```js
// before
if (!transformOptions.lang && transformOptions.jsx && transformOptions.jsx !== "preserve") {
  const ext = filename.slice(filename.lastIndexOf("."));
  if (ext === ".js") {
    transformOptions.lang = "jsx";
  } else if (ext === ".ts") {
    transformOptions.lang = "tsx";   // <-- the bug
  }
}
```

In TSX mode, `<T>(...)` is parsed as an opening JSX tag rather than a generic arrow function — hence the parse error.

## Fix

Removed the `.ts` → `lang: "tsx"` branch. The `.tsx` extension is already the explicit way to say "TypeScript + JSX", so `.ts` should stay pure TypeScript. `oxc-transform` infers the language from the file name, so an explicit `lang` for `.ts` is unnecessary.

```js
// after
if (!transformOptions.lang && transformOptions.jsx && transformOptions.jsx !== "preserve") {
  const ext = filename.slice(filename.lastIndexOf("."));
  if (ext === ".js") {
    transformOptions.lang = "jsx";
  }
}
```

The `.js` → `lang: "jsx"` branch is kept: when the user explicitly opts into `jsx` options, a `.js` file may contain JSX, which is a reasonable convention (many projects don't use a separate `.jsx` extension).

## Regression test

Added `transforms TypeScript and TSX together in one build`, which bundles both fixtures simultaneously with `jsx.runtime: "automatic"` enabled. Without the fix, the test fails on parsing the generic arrow in `typescript.ts`.

```js
it("transforms TypeScript and TSX together in one build", async () => {
  const files = await compile(
    [
      path.join(__dirname, "fixtures", "typescript.ts"),
      path.join(__dirname, "fixtures", "typescript-jsx.tsx"),
    ],
    { jsx: { runtime: "automatic" } },
  );
  expect(files["bundle.js"]).toContain("greet");
  expect(files["bundle.js"]).toContain("react/jsx-runtime");
  expect(files["bundle.js"]).not.toContain(": string");
  expect(files["bundle.js"]).not.toContain(": Props");
  expect(files["bundle.js"]).not.toContain("<div>");
});
```

A generic arrow function `traverse` was added to `test/fixtures/typescript.ts` — it's the marker that breaks specifically in TSX mode, so it doubles as the canary for this bug.

## Test plan

- [x] `npx vitest run test/loader.test.js` — all 10 tests pass
- [x] The new `transforms TypeScript and TSX together in one build` test fails on `main` without the fix and passes with it
- [x] Existing tests (`transforms TypeScript`, `transforms TSX`, JSX classic/automatic) are unaffected
