### PR TITLE
chore: update packageManager to pnpm 11.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "vitest": "^4.0.18",
     "webpack": "^5.98.0"
   },
-  "packageManager": "pnpm@10.30.2",
+  "packageManager": "pnpm@11.0.4",
   "peerDependencies": {
     "oxc-transform": "^0.115.0",
     "webpack": ">=5"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,8 @@ packages:
   - example-config
   - example-src-dir
   - example-sync
+allowBuilds:
+  esbuild: true
 
 catalog:
   react: ^19.2.4


### PR DESCRIPTION
## Summary
- update the pnpm package manager pin to `pnpm@11.0.4`
- add missing pnpm package manager metadata where needed
- keep lockfiles unchanged to avoid unrelated dependency updates