### PR TITLE
ci: switch security workflow to ubuntu-latest

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,6 +19,6 @@ concurrency:
 jobs:
   security:
     name: Security Analysis
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     steps:
       - uses: oxc-project/security-action@fbbd523b1e765ceb174cb819b92c453bb1da265e # v1.0.0


### PR DESCRIPTION
This updates the security workflow on `main` from `ubuntu-slim` to `ubuntu-latest`.

Only the `runs-on` label in `.github/workflows/security.yml` is changed.