### PR TITLE
ci: use voidzero-dev/setup-vp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,4 @@ jobs:
         with:
           cache: true
       - run: vp test
-      - name: Build examples
-        run: |
-          for d in example example-config example-src-dir example-sync; do
-            echo "::group::build $d"
-            (cd "$d" && vp run build)
-            echo "::endgroup::"
-          done
+      - run: vp run --filter './example*' build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,14 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - run: corepack enable
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: voidzero-dev/setup-vp@40646972e9ea5e33609c1bb31ac6a27fb01b641e # v1.10.0
         with:
-          node-version: lts/*
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm test
-      - run: pnpm --filter './example*' exec webpack
+          cache: true
+      - run: vp test
+      - name: Build examples
+        run: |
+          for d in example example-config example-src-dir example-sync; do
+            echo "::group::build $d"
+            (cd "$d" && vp run build)
+            echo "::endgroup::"
+          done


### PR DESCRIPTION
Switch CI to [`voidzero-dev/setup-vp`](https://github.com/voidzero-dev/setup-vp) now that the project is on Vite+.

- replace `corepack` + `actions/setup-node` + `pnpm install` with `setup-vp` (`cache: true`, auto-runs `vp install`)
- `pnpm test` → `vp test`
- `pnpm --filter './example*' exec webpack` → `vp run --filter './example*' build` (`vp run` supports pnpm-style workspace filtering and builds all example packages in parallel)