### PR TITLE
ci: align release workflow with oxc-webpack-plugin (use Vite+)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,59 +2,44 @@ name: Release
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
     paths:
       - package.json
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   check-version:
+    name: detect version bump
     runs-on: ubuntu-latest
     outputs:
-      version_changed: ${{ steps.check.outputs.changed }}
+      changed: ${{ steps.check.outputs.changed }}
       version: ${{ steps.check.outputs.version }}
     steps:
-      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
-
-      - name: Check if version changed
-        id: check
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - id: check
         uses: EndBug/version-check@095362f3cd50f690c8fa0e6afeea81834bd8d320 # v3.0.0
         with:
-          static-checking: localIsNew
           file-url: https://unpkg.com/oxc-webpack-loader@latest/package.json
-          file-name: ./package.json
+          static-checking: localIsNew
 
-  release:
+  publish:
+    name: publish to npm
     needs: check-version
-    if: needs.check-version.outputs.version_changed == 'true'
+    if: needs.check-version.outputs.changed == 'true'
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
       id-token: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: voidzero-dev/setup-vp@40646972e9ea5e33609c1bb31ac6a27fb01b641e # v1.10.0
         with:
-          persist-credentials: false
-
-      - run: corepack enable
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: lts/*
-          registry-url: https://registry.npmjs.org
-          package-manager-cache: false
-
-      - run: pnpm install --frozen-lockfile
-
-      - name: Publish to npm
-        run: pnpm publish --provenance --access public
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
-        with:
-          draft: false
-          name: v${{ needs.check-version.outputs.version }}
-          tag_name: v${{ needs.check-version.outputs.version }}
-          target_commitish: ${{ github.sha }}
-          generate_release_notes: true
+          cache: true
+      - run: vp test
+      - run: vp pm publish --provenance --access public
+      - run: gh release create "v${{ needs.check-version.outputs.version }}" --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
       version: ${{ steps.check.outputs.version }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - id: check
         uses: EndBug/version-check@095362f3cd50f690c8fa0e6afeea81834bd8d320 # v3.0.0
         with:
@@ -35,6 +37,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - uses: voidzero-dev/setup-vp@40646972e9ea5e33609c1bb31ac6a27fb01b641e # v1.10.0
         with:
           cache: true


### PR DESCRIPTION
Aligns the release workflow with [oxc-webpack-plugin](https://github.com/oxc-project/oxc-webpack-plugin).

## Changes

- Switched from pnpm/corepack to **Vite+ (`vp`)** via `voidzero-dev/setup-vp`, consistent with the recent Vite+ migration and `ci.yml`.
- Version detection via `EndBug/version-check` (points at the `oxc-webpack-loader` package).
- Publish job uses `environment: release`, runs `vp test`, then `vp pm publish --provenance --access public`, and creates a GitHub release via `gh release create --generate-notes`.
- Dropped the plugin's build step — the loader publishes \`src\` directly (no build/dist).

> Note: requires a \`release\` environment configured in the repo's GitHub settings for OIDC/trusted publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)