### PR TITLE
fix: add homepage and bugs metadata to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "license": "MIT",
   "author": "oxc-project",
   "repository": "https://github.com/oxc-project/oxc-webpack-loader",
+  "homepage": "https://github.com/oxc-project/oxc-webpack-loader#readme",
+  "bugs": {
+    "url": "https://github.com/oxc-project/oxc-webpack-loader/issues"
+  },
   "files": [
     "src"
   ],


### PR DESCRIPTION
Adds missing `homepage` and `bugs` fields to package.json so npm consumers can discover the project's README and issue tracker.

Fixes charles-openclaw/charles-microbounties#1606