### PR TITLE
fix: handle preserved jsx loader inputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+/example*/build/

--- a/src/index.js
+++ b/src/index.js
@@ -1,59 +1,69 @@
 const { transform, transformSync } = require("oxc-transform");
 
+function getLoaderOptions(loaderContext) {
+  if (typeof loaderContext.getOptions !== "function") {
+    return {};
+  }
+  return loaderContext.getOptions() || {};
+}
+
+function shouldUseSourceMap(loaderContext, loaderOptions) {
+  return loaderOptions.sourcemap === undefined
+    ? !!loaderContext.sourceMap
+    : !!loaderOptions.sourcemap;
+}
+
+function getTransformOptions(loaderContext, filename) {
+  const loaderOptions = getLoaderOptions(loaderContext);
+  const { sync = false, ...transformOptions } = loaderOptions;
+
+  transformOptions.sourcemap = shouldUseSourceMap(loaderContext, loaderOptions);
+
+  if (
+    loaderContext.mode &&
+    transformOptions.jsx &&
+    typeof transformOptions.jsx === "object" &&
+    !Object.prototype.hasOwnProperty.call(transformOptions.jsx, "development")
+  ) {
+    transformOptions.jsx = {
+      ...transformOptions.jsx,
+      development: loaderContext.mode === "development",
+    };
+  }
+
+  if (!transformOptions.lang && transformOptions.jsx && filename.endsWith(".js")) {
+    transformOptions.lang = "jsx";
+  }
+
+  return { sync, transformOptions };
+}
+
+function createTransformError(errors) {
+  return new Error(errors.map((error) => error.message).join("\n"));
+}
+
+function handleTransformResult(callback, output) {
+  if (output.errors.length > 0) {
+    callback(createTransformError(output.errors));
+    return;
+  }
+  callback(null, output.code, output.map ?? undefined);
+}
+
 function makeLoader() {
   return function (source, _inputSourceMap) {
     const callback = this.async();
     const filename = this.resourcePath;
-
-    let loaderOptions = (typeof this.getOptions === "function" ? this.getOptions() : {}) || {};
-
-    const sourceMaps =
-      loaderOptions.sourcemap === undefined ? this.sourceMap : loaderOptions.sourcemap;
-
-    const transformOptions = Object.assign({}, loaderOptions, {
-      sourcemap: !!sourceMaps,
-    });
-
-    // Auto detect development mode for JSX
-    if (
-      this.mode &&
-      transformOptions.jsx &&
-      typeof transformOptions.jsx === "object" &&
-      !Object.prototype.hasOwnProperty.call(transformOptions.jsx, "development")
-    ) {
-      transformOptions.jsx = Object.assign({}, transformOptions.jsx, {
-        development: this.mode === "development",
-      });
-    }
-
-    // Auto detect lang when jsx options are provided but file has .js extension
-    if (!transformOptions.lang && transformOptions.jsx && transformOptions.jsx !== "preserve") {
-      const ext = filename.slice(filename.lastIndexOf("."));
-      if (ext === ".js") {
-        transformOptions.lang = "jsx";
-      }
-    }
-
-    // Remove loader-specific options
-    const sync = transformOptions.sync;
-    delete transformOptions.sync;
+    const { sync, transformOptions } = getTransformOptions(this, filename);
 
     try {
       if (sync) {
         const output = transformSync(filename, source, transformOptions);
-        if (output.errors.length > 0) {
-          callback(new Error(output.errors.map((e) => e.message).join("\n")));
-          return;
-        }
-        callback(null, output.code, output.map ?? undefined);
+        handleTransformResult(callback, output);
       } else {
         transform(filename, source, transformOptions).then(
           (output) => {
-            if (output.errors.length > 0) {
-              callback(new Error(output.errors.map((e) => e.message).join("\n")));
-              return;
-            }
-            callback(null, output.code, output.map ?? undefined);
+            handleTransformResult(callback, output);
           },
           (err) => {
             callback(err);

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -1,8 +1,20 @@
 import { describe, it, expect } from "vite-plus/test";
+import { createRequire } from "module";
 import path from "path";
 import fs from "fs";
 import os from "os";
 import webpack from "webpack";
+
+const require = createRequire(import.meta.url);
+const makeLoader = require("../src/index.js").custom;
+
+function readOutputFiles(outputDir) {
+  const files = {};
+  for (const file of fs.readdirSync(outputDir)) {
+    files[file] = fs.readFileSync(path.join(outputDir, file), "utf-8");
+  }
+  return files;
+}
 
 function compile(entry, loaderOptions = {}, webpackOptions = {}) {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "oxc-loader-test-"));
@@ -31,21 +43,57 @@ function compile(entry, loaderOptions = {}, webpackOptions = {}) {
 
   return new Promise((resolve, reject) => {
     compiler.run((err, stats) => {
-      if (err) {
-        reject(err);
-        return;
+      let error = err;
+      let files;
+
+      try {
+        if (!error && stats.hasErrors()) {
+          error = new Error(stats.compilation.errors.map((e) => e.message).join("\n"));
+        }
+        if (!error) {
+          files = readOutputFiles(tmpDir);
+        }
+      } catch (readError) {
+        error = readError;
       }
-      if (stats.hasErrors()) {
-        reject(new Error(stats.compilation.errors.map((e) => e.message).join("\n")));
-        return;
-      }
-      const files = {};
-      for (const file of fs.readdirSync(tmpDir)) {
-        files[file] = fs.readFileSync(path.join(tmpDir, file), "utf-8");
-      }
-      fs.rmSync(tmpDir, { recursive: true });
-      resolve(files);
+
+      compiler.close((closeError) => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+        if (error || closeError) {
+          reject(error || closeError);
+          return;
+        }
+        resolve(files);
+      });
     });
+  });
+}
+
+function runLoader(
+  source,
+  { filename = "input.js", getOptions, mode = "none", options = {}, sourceMap = false } = {},
+) {
+  return new Promise((resolve, reject) => {
+    const loaderContext = {
+      async() {
+        return (error, code, map) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve({ code, map });
+        };
+      },
+      mode,
+      resourcePath: path.join(__dirname, "fixtures", filename),
+      sourceMap,
+    };
+
+    if (getOptions !== false) {
+      loaderContext.getOptions = () => options;
+    }
+
+    makeLoader().call(loaderContext, source);
   });
 }
 
@@ -149,5 +197,64 @@ describe("oxc-loader", () => {
       { mode: "development" },
     );
     expect(files["bundle.js"]).toContain("jsx-dev-runtime");
+  });
+
+  it("parses JSX in .js files when JSX should be preserved", async () => {
+    const { code } = await runLoader("const element = <span />;", {
+      filename: "component.js",
+      options: {
+        jsx: "preserve",
+      },
+    });
+
+    expect(code).toContain("const element = <span />;");
+  });
+
+  it("does not override an explicit JSX development option", async () => {
+    const { code } = await runLoader("const element = <span />;", {
+      filename: "component.js",
+      mode: "development",
+      options: {
+        jsx: {
+          development: false,
+          runtime: "automatic",
+        },
+      },
+    });
+
+    expect(code).toContain("react/jsx-runtime");
+    expect(code).not.toContain("react/jsx-dev-runtime");
+  });
+
+  it("enables source maps from webpack's sourceMap flag", async () => {
+    const { map } = await runLoader('console.log("mapped");', {
+      sourceMap: true,
+    });
+
+    expect(map).toBeDefined();
+    expect(map.version).toBe(3);
+  });
+
+  it("lets loader sourcemap options override webpack's sourceMap flag", async () => {
+    const { map } = await runLoader('console.log("unmapped");', {
+      options: {
+        sourcemap: false,
+      },
+      sourceMap: true,
+    });
+
+    expect(map).toBeUndefined();
+  });
+
+  it("works when webpack does not expose getOptions", async () => {
+    const { code } = await runLoader('console.log("fallback");', {
+      getOptions: false,
+    });
+
+    expect(code).toContain("fallback");
+  });
+
+  it("reports transform errors through the webpack callback", async () => {
+    await expect(runLoader("const value = ;")).rejects.toThrow("Unexpected");
   });
 });


### PR DESCRIPTION
Refactors loader option normalization and transform result handling, fixes `jsx: "preserve"` parsing for `.js` inputs, and expands coverage for source maps, JSX development options, legacy loader contexts, and transform errors.

Validation:
- `vp check`
- `vp test`
- `vp run --filter './example*' build`