### PR TITLE
test: harden loader coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+/example*/build/

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -1,8 +1,20 @@
 import { describe, it, expect } from "vite-plus/test";
+import { createRequire } from "module";
 import path from "path";
 import fs from "fs";
 import os from "os";
 import webpack from "webpack";
+
+const require = createRequire(import.meta.url);
+const makeLoader = require("../src/index.js").custom;
+
+function readOutputFiles(outputDir) {
+  const files = {};
+  for (const file of fs.readdirSync(outputDir)) {
+    files[file] = fs.readFileSync(path.join(outputDir, file), "utf-8");
+  }
+  return files;
+}
 
 function compile(entry, loaderOptions = {}, webpackOptions = {}) {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "oxc-loader-test-"));
@@ -31,21 +43,57 @@ function compile(entry, loaderOptions = {}, webpackOptions = {}) {
 
   return new Promise((resolve, reject) => {
     compiler.run((err, stats) => {
-      if (err) {
-        reject(err);
-        return;
+      let error = err;
+      let files;
+
+      try {
+        if (!error && stats.hasErrors()) {
+          error = new Error(stats.compilation.errors.map((e) => e.message).join("\n"));
+        }
+        if (!error) {
+          files = readOutputFiles(tmpDir);
+        }
+      } catch (readError) {
+        error = readError;
       }
-      if (stats.hasErrors()) {
-        reject(new Error(stats.compilation.errors.map((e) => e.message).join("\n")));
-        return;
-      }
-      const files = {};
-      for (const file of fs.readdirSync(tmpDir)) {
-        files[file] = fs.readFileSync(path.join(tmpDir, file), "utf-8");
-      }
-      fs.rmSync(tmpDir, { recursive: true });
-      resolve(files);
+
+      compiler.close((closeError) => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+        if (error || closeError) {
+          reject(error || closeError);
+          return;
+        }
+        resolve(files);
+      });
     });
+  });
+}
+
+function runLoader(
+  source,
+  { filename = "input.js", getOptions, mode = "none", options = {}, sourceMap = false } = {},
+) {
+  return new Promise((resolve, reject) => {
+    const loaderContext = {
+      async() {
+        return (error, code, map) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve({ code, map });
+        };
+      },
+      mode,
+      resourcePath: path.join(__dirname, "fixtures", filename),
+      sourceMap,
+    };
+
+    if (getOptions !== false) {
+      loaderContext.getOptions = () => options;
+    }
+
+    makeLoader().call(loaderContext, source);
   });
 }
 
@@ -149,5 +197,53 @@ describe("oxc-loader", () => {
       { mode: "development" },
     );
     expect(files["bundle.js"]).toContain("jsx-dev-runtime");
+  });
+
+  it("does not override an explicit JSX development option", async () => {
+    const { code } = await runLoader("const element = <span />;", {
+      filename: "component.js",
+      mode: "development",
+      options: {
+        jsx: {
+          development: false,
+          runtime: "automatic",
+        },
+      },
+    });
+
+    expect(code).toContain("react/jsx-runtime");
+    expect(code).not.toContain("react/jsx-dev-runtime");
+  });
+
+  it("enables source maps from webpack's sourceMap flag", async () => {
+    const { map } = await runLoader('console.log("mapped");', {
+      sourceMap: true,
+    });
+
+    expect(map).toBeDefined();
+    expect(map.version).toBe(3);
+  });
+
+  it("lets loader sourcemap options override webpack's sourceMap flag", async () => {
+    const { map } = await runLoader('console.log("unmapped");', {
+      options: {
+        sourcemap: false,
+      },
+      sourceMap: true,
+    });
+
+    expect(map).toBeUndefined();
+  });
+
+  it("works when webpack does not expose getOptions", async () => {
+    const { code } = await runLoader('console.log("fallback");', {
+      getOptions: false,
+    });
+
+    expect(code).toContain("fallback");
+  });
+
+  it("reports transform errors through the webpack callback", async () => {
+    await expect(runLoader("const value = ;")).rejects.toThrow("Unexpected");
   });
 });


### PR DESCRIPTION
Expands loader coverage for source maps, explicit JSX development settings, legacy loader contexts, and transform error reporting. Also cleans up webpack test temp dirs and ignores generated example build outputs.

Validation:
- `vp check`
- `vp test`
- `vp run --filter './example*' build`